### PR TITLE
Updated lib.rs to prevent calling devirtualize 2 times

### DIFF
--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -47,8 +47,6 @@ static mut HYPERVISOR: Option<Hypervisor> = None;
 
 pub extern "system" fn driver_unload(_driver: &mut DRIVER_OBJECT) {
     if let Some(mut hv) = unsafe { HYPERVISOR.take() } {
-        hv.devirtualize();
-
         core::mem::drop(hv);
     }
 }


### PR DESCRIPTION
The kernel driver's `driver_unload` function calls devirtualize function 2 times via `hv.devirtualize()` and `core::mem::drop(hv)` which are doing the same thing in a different way and this could lead to BSOD/undefined behaviour. 

Edit: Please note that the `hv` variable does not need to be `mut` anymore. I forgot to change it in this commit.